### PR TITLE
Rad: Optimise MultiChildWidget.shouldUpdateWidget

### DIFF
--- a/packages/rad_bootstrap/lib/src/rad_bootstrap_base.dart
+++ b/packages/rad_bootstrap/lib/src/rad_bootstrap_base.dart
@@ -196,11 +196,8 @@ class MultiChildWidget extends rad.Widget {
   rad.DomTagType? get correspondingTag => null;
 
   @override
-  bool shouldUpdateWidget(covariant MultiChildWidget oldWidget) {
-    return oldWidget.children != children &&
-        (oldWidget.children.length != children.length ||
-            Iterable.generate(children.length)
-                .any((i) => children[i] != oldWidget.children[i]));
+  bool shouldUpdateWidget(oldWidget) {
+    return false;
   }
 }
 


### PR DESCRIPTION
#### Changes

- Remove diffing logic that compares child widgets.
- Return false(since MultiChildWidget itself has no mutable parts).

<details>
<summary>Additional details on Widget lifecycle</summary>
<p>

Rad calls `shouldUpdateWidget` on new widget, when new widget matches with a old widget, to check whether old widget need to update. This method should contain the logic to compare new widget with old. Important thing to note here is that diffing process will always call `shouldUpdateWidget` on child widgets of current widget even if `shouldUpdateWidget` return false. This means whatever diffing logic is present in this method, its scope should be limited to checking just the current widget. If a widget want to short-circuit diffing process(i.e no `shouldUpdateWidget` on child widgets) then it can override `shouldUpdateWidgetChildren` method. 

When a widget should override `shouldUpdateWidgetChildren` ?

1. If a widget involves complex rendering logic(such as ListView) and doesn't want the framework to interfere. 
2. If only thing we care about is performance and child widgets are known in advance(such as in a template [1](https://github.com/erlage/rad-benchmarks/blob/23cbed6479c95b09f3144cb38d113ddb5a6a5a5f/frameworks/keyed/rad/web/jumbotron.dart#L9]), [2](https://github.com/erlage/rad-benchmarks/blob/23cbed6479c95b09f3144cb38d113ddb5a6a5a5f/frameworks/keyed/rad/web/main.dart#L173)).

Returning false from `shouldUpdateWidget` does helps a bit as it tells Rad to skip patching MultiChildWidget(but that doesn't mean Rad will skip child widgets as well). For skipping child widgets we can override `shouldUpdateWidgetChildren` but there's no need to override it as MultiChildWidget doesn't care when and how it's child widgets are rendered so Rad will automatically optimise it where it can, as best as possible.

I know we need a proper documentation for Rad but I hope this helps for now.

</p>
</details>